### PR TITLE
Feature/DGI-43: Redirected change password page

### DIFF
--- a/frontend/src/components/Header/HeaderBtns/HeaderBtns.tsx
+++ b/frontend/src/components/Header/HeaderBtns/HeaderBtns.tsx
@@ -1,16 +1,19 @@
 import { HStack } from "@chakra-ui/react";
-import { FC } from "react";
+import { AuthContext } from "contexts/AuthContext";
+import { FC, useContext } from "react";
 
 import ColorModeBtn from "./ColorModeBtn";
 import LocaleBtn from "./LocaleBtn";
 import UserBtn from "./UserBtn";
 
 const HeaderButtons: FC = () => {
+  const { activeUser } = useContext(AuthContext);
+
   return (
     <HStack spacing={3}>
       <LocaleBtn />
       <ColorModeBtn />
-      <UserBtn />
+      {activeUser && <UserBtn />}
     </HStack>
   );
 };

--- a/frontend/src/components/Layouts/BasicLayout.tsx
+++ b/frontend/src/components/Layouts/BasicLayout.tsx
@@ -4,11 +4,14 @@ import { FC, ReactNode } from "react";
 
 interface Props {
   children?: ReactNode;
+  maxW?: string;
 }
 
-const BasicLayout: FC<Props> = ({ children }) => {
+const BasicLayout: FC<Props> = ({ children, maxW }) => {
   return (
-    <Grid gridTemplateColumns="1fr minmax(400px, 80vw) 1fr" gridTemplateRows="auto 1fr">
+    <Grid
+      gridTemplateColumns={`1fr minmax(400px, ${maxW ?? "80vw"}) 1fr`}
+      gridTemplateRows="auto 1fr">
       <GridItem rowSpan={1} colSpan={3}>
         <Header />
       </GridItem>

--- a/frontend/src/components/User/ChangePassword/ChangePassword.tsx
+++ b/frontend/src/components/User/ChangePassword/ChangePassword.tsx
@@ -1,0 +1,32 @@
+import { Container, Heading, Stack } from "@chakra-ui/react";
+import BasicLayout from "components/Layouts/BasicLayout";
+import { setAuthToken } from "hooks/useAuth";
+import { useLocales } from "hooks/useLocales";
+import { useRouter } from "next/router";
+import { FC, useEffect } from "react";
+
+import ChangePasswordForm from "./ChangePasswordForm";
+
+const ChangePassword: FC = () => {
+  const { t } = useLocales();
+  const router = useRouter();
+
+  useEffect(() => {
+    const token = router.query.token as string;
+    if (token) {
+      setAuthToken(token);
+    }
+  }, [router, router.query]);
+
+  return (
+    <BasicLayout maxW="600px">
+      <Stack spacing={4}>
+        <Heading>{t("password.changePassword")}</Heading>
+        <Container maxW="400px" pt="50px">
+          <ChangePasswordForm />
+        </Container>
+      </Stack>
+    </BasicLayout>
+  );
+};
+export default ChangePassword;

--- a/frontend/src/components/User/ChangePassword/ChangePasswordForm.tsx
+++ b/frontend/src/components/User/ChangePassword/ChangePasswordForm.tsx
@@ -5,6 +5,7 @@ import {
   FormErrorMessage,
   FormLabel,
   Input,
+  Stack,
   useToast
 } from "@chakra-ui/react";
 import { useAuth } from "hooks/useAuth";
@@ -51,7 +52,8 @@ const ChangePasswordForm: FC<Props> = ({ onSubmit }) => {
           description: t("password.changeSuccessText"),
           status: "success",
           duration: 5000,
-          isClosable: true
+          isClosable: true,
+          position: "bottom-left"
         });
         onSubmit(true);
       } catch {
@@ -60,7 +62,8 @@ const ChangePasswordForm: FC<Props> = ({ onSubmit }) => {
           description: t("password.changeFailText"),
           status: "error",
           duration: 5000,
-          isClosable: true
+          isClosable: true,
+          position: "bottom-left"
         });
       }
     },
@@ -69,28 +72,35 @@ const ChangePasswordForm: FC<Props> = ({ onSubmit }) => {
 
   return (
     <form onSubmit={handleSubmit}>
-      <FormControl id="password" isRequired isInvalid={!validationResult.isValid}>
-        <FormLabel htmlFor="password">{t("users.password")}</FormLabel>
-        <Input type="password" value={password} onChange={e => setPassword(e.target.value)}></Input>
-      </FormControl>
-      <FormControl id="passwordRepeat" isRequired isInvalid={!validationResult.repetitionValid}>
-        <FormLabel htmlFor="passwordRepeat">{t("users.repeatPassword")}</FormLabel>
-        <Input
-          type="password"
-          value={passwordRep}
-          onChange={e => setPasswordRep(e.target.value)}></Input>
-      </FormControl>
-      <FormControl isInvalid={!validationResult.isValid || !validationResult.repetitionValid}>
-        {validationResult.errors.map((err, i) => (
-          <FormErrorMessage key={i}>{err.errorMsg}</FormErrorMessage>
-        ))}
-        {!validationResult.repetitionValid && (
-          <FormErrorMessage>{t("password.dontMatch")}</FormErrorMessage>
-        )}
-      </FormControl>
+      <Stack spacing={5}>
+        <FormControl id="password" isRequired isInvalid={!validationResult.isValid}>
+          <FormLabel htmlFor="password">{t("password.password")}</FormLabel>
+          <Input
+            type="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            maxW="500px"></Input>
+        </FormControl>
+        <FormControl id="passwordRepeat" isRequired isInvalid={!validationResult.repetitionValid}>
+          <FormLabel htmlFor="passwordRepeat">{t("password.repeatPassword")}</FormLabel>
+          <Input
+            type="password"
+            value={passwordRep}
+            onChange={e => setPasswordRep(e.target.value)}
+            maxW="500px"></Input>
+        </FormControl>
+        <FormControl isInvalid={!validationResult.isValid || !validationResult.repetitionValid}>
+          {validationResult.errors.map((err, i) => (
+            <FormErrorMessage key={i}>{err.errorMsg}</FormErrorMessage>
+          ))}
+          {!validationResult.repetitionValid && (
+            <FormErrorMessage>{t("password.dontMatch")}</FormErrorMessage>
+          )}
+        </FormControl>
+      </Stack>
       <Flex justifyContent="flex-end" w="100%" mt={5}>
         <Button colorScheme="green" type="submit">
-          {t("common.add")}
+          {t("actions.update")}
         </Button>
       </Flex>
     </form>

--- a/frontend/src/components/User/ChangePassword/ChangePasswordForm.tsx
+++ b/frontend/src/components/User/ChangePassword/ChangePasswordForm.tsx
@@ -8,10 +8,10 @@ import {
   Stack,
   useToast
 } from "@chakra-ui/react";
-import { useAuth } from "hooks/useAuth";
+import { AuthContext } from "contexts/AuthContext";
 import { useLocales } from "hooks/useLocales";
 import { pwValidationResult, usePasswordValidation } from "hooks/usePasswordValidation";
-import { FC, useCallback, useState } from "react";
+import { FC, useCallback, useContext, useState } from "react";
 import { genUserClient } from "services/backend/apiClients";
 import { UpdatePasswordCommand } from "services/backend/nswagts";
 
@@ -20,7 +20,7 @@ interface Props {
 }
 
 const ChangePasswordForm: FC<Props> = ({ onSubmit }) => {
-  const { activeUser } = useAuth();
+  const { activeUser } = useContext(AuthContext);
   const { t } = useLocales();
   const { validatePassword } = usePasswordValidation();
   const toast = useToast();

--- a/frontend/src/i18n/Locale.ts
+++ b/frontend/src/i18n/Locale.ts
@@ -55,15 +55,19 @@ export interface Locale {
   };
 
   actions: {
+    update: string;
     delete: string;
   };
 
   password: {
+    password: string;
+    repeatPassword: string;
     dontMatch: string;
     tooShort: string;
     missingUppercase: string;
     missingLowercase: string;
     missingNumber: string;
+    changePassword: string;
     changeSuccessTitle: string;
     changeSuccessText: string;
     changeFailTitle: string;

--- a/frontend/src/i18n/da-DK.ts
+++ b/frontend/src/i18n/da-DK.ts
@@ -57,15 +57,19 @@ export const table: Locale = {
   },
 
   actions: {
+    update: "Opdatér",
     delete: "Slet"
   },
 
   password: {
+    password: "Password:",
+    repeatPassword: "Gentag password:",
     dontMatch: "De to passwords er ikke ens.",
     tooShort: "Skal være på minds 8 karakterer.",
     missingUppercase: "Skal have mindst ét stort bogstav.",
     missingLowercase: "Skal have mindst ét lille bogstav.",
     missingNumber: "Skal have mindst ét tal.",
+    changePassword: "Opdater password",
     changeSuccessTitle: "Password opdateret",
     changeSuccessText: "Dit password er nu blevet opdateret.",
     changeFailTitle: "Fejl",

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -57,15 +57,19 @@ export const table: Locale = {
   },
 
   actions: {
+    update: "Update",
     delete: "Delete"
   },
 
   password: {
+    password: "Password:",
+    repeatPassword: "Repeat password:",
     dontMatch: "De to passwords er ikke ens.",
     tooShort: "Skal være på minds 8 karakterer.",
     missingUppercase: "Skal have mindst ét stort bogstav.",
     missingLowercase: "Skal have mindst ét lille bogstav.",
     missingNumber: "Skal have mindst ét tal.",
+    changePassword: "Update password",
     changeSuccessTitle: "Password updatet",
     changeSuccessText: "Your password has been updated.",
     changeFailTitle: "Error",

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -7,6 +7,7 @@ import { AuthStage, useAuth } from "hooks/useAuth";
 import { usePWA } from "hooks/usePWA";
 import { AppPropsType } from "next/dist/next-server/lib/utils";
 import Head from "next/head";
+import { useRouter } from "next/router";
 import { I18nProvider } from "next-rosetta";
 import { ReactElement, useEffect } from "react";
 import EnvSettings from "types/EnvSettings";
@@ -25,6 +26,7 @@ const MyApp = ({ Component, pageProps, __N_SSG }: AppPropsType & Props): ReactEl
   // usePWA(); //! OPT IN
 
   const auth = useAuth();
+  const router = useRouter();
 
   useEffect(() => {
     if (!__N_SSG) {
@@ -68,7 +70,7 @@ const MyApp = ({ Component, pageProps, __N_SSG }: AppPropsType & Props): ReactEl
         <ChakraProvider theme={theme}>
           <AuthContext.Provider value={auth}>
             {/* <SignalRContext.Provider value={{ connection }}> */}
-            {auth.authStage == AuthStage.AUTHENTICATED ? (
+            {auth.authStage == AuthStage.AUTHENTICATED || router.pathname == "/changepassword" ? (
               <Component {...pageProps} />
             ) : (
               <LoginPage />

--- a/frontend/src/pages/changepassword.tsx
+++ b/frontend/src/pages/changepassword.tsx
@@ -1,17 +1,11 @@
-import ChangePasswordForm from "components/User/ChangePassword/ChangePasswordForm";
+import ChangePassword from "components/User/ChangePassword/ChangePassword";
 import { Locale } from "i18n/Locale";
 // import { runTimeTable } from "i18n/runtimeTable";
 import { GetStaticProps, NextPage } from "next";
 import { I18nProps } from "next-rosetta";
 
 const ChangePasswordPage: NextPage = () => {
-  return (
-    <ChangePasswordForm
-      onSubmit={() => {
-        return;
-      }}
-    />
-  );
+  return <ChangePassword />;
 };
 
 export const getStaticProps: GetStaticProps<I18nProps<Locale>> = async context => {


### PR DESCRIPTION
Frontend page to receive token from redirect and serve change password page.
I'm not really sure if I'm taking the right approach on this page. I'm reading the token from the router query params and then calling setAuthtoken in a useEffect.

I had to make a few changes to _app.tsx to be able to access the page without being authenticated. And I had to make a small change to the header to display properly while unauthenticated.