### PR TITLE
Fix: Change TokenService claims to use emails instead of Id

### DIFF
--- a/backend/Application.UnitTests/Users/Commands/UpdatePasswordCommandTest/UpdatePasswordCommandTest.cs
+++ b/backend/Application.UnitTests/Users/Commands/UpdatePasswordCommandTest/UpdatePasswordCommandTest.cs
@@ -5,6 +5,7 @@ using Application.Common.Exceptions;
 using Application.Common.Interfaces;
 using Application.Users.Commands.UpdatePassword;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using Moq;
 using Xunit;
 
@@ -18,11 +19,11 @@ namespace Application.UnitTests.Users.Commands.UpdatePasswordCommandTest
     {
       CurrentUserServiceMock = new Mock<ICurrentUserService>();
       CurrentUserServiceMock.Setup(m => m.UserId)
-        .Returns("1");
+        .Returns("test1@test1.dk");
 
       CurrentUserServiceMock2 = new Mock<ICurrentUserService>();
       CurrentUserServiceMock2.Setup(m => m.UserId)
-        .Returns("99");
+        .Returns("invalidmail@invalidmail.dk");
     }
 
     [Fact]
@@ -37,7 +38,7 @@ namespace Application.UnitTests.Users.Commands.UpdatePasswordCommandTest
 
       await handler.Handle(command, CancellationToken.None);
 
-      var entity = Context.Users.Find(int.Parse(CurrentUserServiceMock.Object.UserId));
+      var entity = await Context.Users.FirstOrDefaultAsync(x => x.Email == CurrentUserServiceMock.Object.UserId);
 
       entity.Should().NotBeNull();
       entity.Password.Should().Be(PasswordHasherMock.Object.Hash(command.NewPassword));

--- a/backend/Application/Accounts/Queries/GetCurrentAccount/GetCurrentAccountQuery.cs
+++ b/backend/Application/Accounts/Queries/GetCurrentAccount/GetCurrentAccountQuery.cs
@@ -33,7 +33,7 @@ namespace Application.Accounts.Queries.GetCurrentAccountQuery
         var viewmodel = await _context.Accounts
           .Include(a => a.Users)
           .ProjectTo<AccountDto>(_mapper.ConfigurationProvider)
-          .FirstOrDefaultAsync(a => a.Users.Any(u => u.Id == int.Parse(_currentUserService.UserId)));
+          .FirstOrDefaultAsync(a => a.Users.Any(u => u.Email == _currentUserService.UserId));
 
         return viewmodel;
       }

--- a/backend/Application/Common/Interfaces/ITokenService.cs
+++ b/backend/Application/Common/Interfaces/ITokenService.cs
@@ -6,6 +6,6 @@ namespace Application.Common.Interfaces
   {
     string CreateToken(IUser user);
     Task<(string, string)> CreateSSOToken(IUser user);
-    Task<(int, string)> ValidateSSOToken(string token);
+    Task<(string, string)> ValidateSSOToken(string token);
   }
 }

--- a/backend/Application/Mails/Queries/GetMailsQuery.cs
+++ b/backend/Application/Mails/Queries/GetMailsQuery.cs
@@ -6,9 +6,12 @@ using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Application.Common.Security;
+using Domain.Enums;
 
 namespace Application.Mails.Queries.GetMailsQuery
 {
+  [Authorize(Role = RoleEnum.Admin)]
   public class GetMailsQuery : IRequest<List<EmailDto>>
   {
     public class GetMailsQueryHandler : IRequestHandler<GetMailsQuery, List<EmailDto>>

--- a/backend/Application/Statements/Commands/SignOffStatement/SignOffStatementCommand.cs
+++ b/backend/Application/Statements/Commands/SignOffStatement/SignOffStatementCommand.cs
@@ -43,7 +43,7 @@ namespace Application.Statements.Commands.SignOffStatement
           throw new InvalidOperationException("Statement is already signed off.");
         }
 
-        var currentUser = await _context.Users.FindAsync(int.Parse(_currentUser.UserId));
+        var currentUser = await _context.Users.FirstOrDefaultAsync(x => x.Email == _currentUser.UserId);
         if (statementEntity.AccountId != currentUser.AccountId)
         {
           throw new UnauthorizedAccessException("Tried to sign off a statement that belongs to another account");

--- a/backend/Application/Statements/Commands/UpdateStatement/UpdateStatementCommand.cs
+++ b/backend/Application/Statements/Commands/UpdateStatement/UpdateStatementCommand.cs
@@ -49,7 +49,7 @@ namespace Application.Statements.Commands.UpdateStatement
           throw new InvalidOperationException("Cannot update a statement that is already signed off.");
         }
 
-        var currentUser = await _context.Users.FindAsync(int.Parse(_currentUser.UserId));
+        var currentUser = await _context.Users.FirstOrDefaultAsync(x => x.Email == _currentUser.UserId);
         if (statementEntity.AccountId != currentUser.AccountId)
         {
           throw new UnauthorizedAccessException("Tried to update a statement that belongs to another account");

--- a/backend/Application/Statements/Queries/GetMyStatements/GetMyStatementsQuery.cs
+++ b/backend/Application/Statements/Queries/GetMyStatements/GetMyStatementsQuery.cs
@@ -30,7 +30,7 @@ namespace Application.Statements.Queries.GetMyStatements
       }
       public async Task<List<StatementDto>> Handle(GetMyStatementsQuery request, CancellationToken cancellationToken)
       {
-        var currentUser = await _context.Users.FindAsync(int.Parse(_currentUser.UserId));
+        var currentUser = await _context.Users.FirstOrDefaultAsync(x => x.Email == _currentUser.UserId);
 
         var statement = await _context.Statements
           .Where(e => e.AccountId == currentUser.AccountId)

--- a/backend/Application/Statements/Queries/GetStatement/GetStatementQuery.cs
+++ b/backend/Application/Statements/Queries/GetStatement/GetStatementQuery.cs
@@ -32,7 +32,7 @@ namespace Application.Statements.Queries.GetMyStatements
       }
       public async Task<StatementDto> Handle(GetStatementQuery request, CancellationToken cancellationToken)
       {
-        var currentUser = await _context.Users.FindAsync(int.Parse(_currentUser.UserId));
+        var currentUser = await _context.Users.FirstOrDefaultAsync(x => x.Email == _currentUser.UserId);
 
         var statement = await _context.Statements
           .Where(e => e.AccountId == currentUser.AccountId && e.Id == request.Id)

--- a/backend/Application/Users/Commands/CheckAuthCommand/CheckAuthCommand.cs
+++ b/backend/Application/Users/Commands/CheckAuthCommand/CheckAuthCommand.cs
@@ -32,12 +32,12 @@ namespace Application.Users.Commands.CheckAuthCommand
       {
 
         IUser user = await _context.Users
-          .FirstOrDefaultAsync(x => x.Id.ToString().Equals(_userAuthService.UserId));
+          .FirstOrDefaultAsync(x => x.Email.Equals(_userAuthService.UserId));
 
         if (user == null)
         {
           user = await _context.Admins
-          .FirstOrDefaultAsync(x => x.Id.ToString().Equals(_userAuthService.UserId));
+          .FirstOrDefaultAsync(x => x.Email.Equals(_userAuthService.UserId));
         }
 
         if (user == null)

--- a/backend/Application/Users/Commands/UpdatePasswordCommand/ResetPasswordCommand.cs
+++ b/backend/Application/Users/Commands/UpdatePasswordCommand/ResetPasswordCommand.cs
@@ -31,22 +31,22 @@ namespace Application.Users.Commands.UpdatePassword
 
       public async Task<UserTokenDto> Handle(ResetPasswordCommand request, CancellationToken cancellationToken)
       {
-        int userId;
+        string userEmail;
         string tokenId;
         try
         {
-          (userId, tokenId) = await _tokenService.ValidateSSOToken(request.SSOToken);
+          (userEmail, tokenId) = await _tokenService.ValidateSSOToken(request.SSOToken);
         }
         catch (Exception e)
         {
           throw new ArgumentException("The provided token was invalid");
         }
 
-        var userEntity = await _context.Users.FindAsync(userId);
+        var userEntity = await _context.Users.FindAsync(userEmail);
 
         if (userEntity == null)
         {
-          throw new NotFoundException(nameof(User), userId);
+          throw new NotFoundException(nameof(User), userEmail);
         }
 
         if (userEntity.SSOTokenId != tokenId)

--- a/backend/Web/Services/TokenService.cs
+++ b/backend/Web/Services/TokenService.cs
@@ -27,7 +27,7 @@ namespace Web.Services
     public string CreateToken(IUser user)
     {
       var claims = new List<Claim>();
-      claims.Add(new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()));
+      claims.Add(new Claim(ClaimTypes.NameIdentifier, user.Email));
       claims.Add(new Claim(ClaimTypes.Role, user.Role.ToString()));
 
       var key = Encoding.ASCII.GetBytes(_options.Secret);
@@ -45,7 +45,7 @@ namespace Web.Services
     public async Task<(string, string)> CreateSSOToken(IUser user)
     {
       var claims = new List<Claim>();
-      claims.Add(new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()));
+      claims.Add(new Claim(ClaimTypes.NameIdentifier, user.Email));
       //Give the token a unique identifier
       claims.Add(new Claim("jti", Guid.NewGuid().ToString()));
 
@@ -63,7 +63,7 @@ namespace Web.Services
       return (token.Id, writtenToken);
     }
 
-    public async Task<(int, string)> ValidateSSOToken(string token)
+    public async Task<(string, string)> ValidateSSOToken(string token)
     {
       var tokenHandler = new JwtSecurityTokenHandler();
       var key = Encoding.ASCII.GetBytes(_options.Secret);
@@ -77,10 +77,9 @@ namespace Web.Services
       }, out SecurityToken validatedToken);
 
       var jwtToken = (JwtSecurityToken) validatedToken;
-      var userId = int.Parse((jwtToken.Claims.FirstOrDefault(claim => claim.Type == "nameid").Value));
+      var userEmail = (jwtToken.Claims.FirstOrDefault(claim => claim.Type == "nameid").Value);
 
-      return (userId, validatedToken.Id);
+      return (userEmail, validatedToken.Id);
     }
   }
 }
-//First(claim => claim.Type == ClaimTypes.NameIdentifier).Value


### PR DESCRIPTION
I've tried to go through all commands/queries and other classes that depends on the id from the tokenservice and change them, so that they use the email. I hope I've got everything.

I chose not to rename "userId" in currentUserService to "userEmail", but maybe I should?